### PR TITLE
Add support for nullable maps, collections and enums

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.tyro.oss</groupId>
     <artifactId>arbitrater</artifactId>
-    <version>0.0.5</version>
+    <version>0.0.6</version>
     <packaging>jar</packaging>
     <url>https://github.com/tyro/arbitrater</url>
     <description>A simple library to generate arbitrary instances of Kotlin classes</description>

--- a/src/main/kotlin/com/tyro/oss/arbitrater/InstanceCreator.kt
+++ b/src/main/kotlin/com/tyro/oss/arbitrater/InstanceCreator.kt
@@ -17,7 +17,10 @@
 package com.tyro.oss.arbitrater
 
 import com.tyro.oss.randomdata.RandomEnum
-import kotlin.reflect.*
+import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
+import kotlin.reflect.KType
+import kotlin.reflect.KTypeProjection
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.full.primaryConstructor
@@ -26,10 +29,15 @@ import kotlin.reflect.full.withNullability
 // TODO: Arrays?
 
 private val wildcardMapType = Map::class.createType(arguments = listOf(KTypeProjection.STAR, KTypeProjection.STAR))
+private val wildcardNullableMapType = Map::class.createType(arguments = listOf(KTypeProjection.STAR, KTypeProjection.STAR), nullable = true)
 private val wildcardCollectionType = Collection::class.createType(arguments = listOf(KTypeProjection.STAR))
+private val wildcardNullableCollectionType = Collection::class.createType(arguments = listOf(KTypeProjection.STAR), nullable = true)
 private val wildcardListType = List::class.createType(arguments = listOf(KTypeProjection.STAR))
+private val wildcardNullableListType = List::class.createType(arguments = listOf(KTypeProjection.STAR), nullable = true)
 private val wildcardSetType = Set::class.createType(arguments = listOf(KTypeProjection.STAR))
+private val wildcardNullableSetType = Set::class.createType(arguments = listOf(KTypeProjection.STAR), nullable = true)
 private val wildcardEnumType = Enum::class.createType(arguments = listOf(KTypeProjection.STAR))
+private val wildcardNullableEnumType = Enum::class.createType(arguments = listOf(KTypeProjection.STAR), nullable = true)
 
 class InstanceCreator<out T : Any>(private val targetClass: KClass<T>, settings: GeneratorSettings = GeneratorSettings())
     : ConfigurableArbitrater(settings, DefaultConfiguration.generators.toMutableMap()) {
@@ -84,8 +92,11 @@ class InstanceCreator<out T : Any>(private val targetClass: KClass<T>, settings:
             settings.generateNulls && isMarkedNullable -> null
             canGenerate(nonNullableType) -> generate(withNullability(false))
             isSubtypeOf(wildcardCollectionType) -> fillCollection(this)
+            isSubtypeOf(wildcardNullableCollectionType) -> fillCollection(this)
             isSubtypeOf(wildcardMapType) -> fillMap(this)
+            isSubtypeOf(wildcardNullableMapType) -> fillMap(this)
             isSubtypeOf(wildcardEnumType) -> RandomEnum.randomEnumValue((classifier as KClass<Enum<*>>).java)
+            isSubtypeOf(wildcardNullableEnumType) -> RandomEnum.randomEnumValue((classifier as KClass<Enum<*>>).java)
             classifier is KClass<*> -> InstanceCreator(classifier as KClass<*>, settings).createInstance()
             else -> TODO("No support for ${this}")
         }
@@ -106,8 +117,11 @@ class InstanceCreator<out T : Any>(private val targetClass: KClass<T>, settings:
 
         return when {
             collectionType.isSubtypeOf(wildcardListType) -> randomValues
+            collectionType.isSubtypeOf(wildcardNullableListType) -> randomValues
             collectionType.isSubtypeOf(wildcardSetType) -> randomValues.toSet()
+            collectionType.isSubtypeOf(wildcardNullableSetType) -> randomValues.toSet()
             collectionType.isSubtypeOf(wildcardCollectionType) -> randomValues
+            collectionType.isSubtypeOf(wildcardNullableCollectionType) -> randomValues
             else -> TODO("No support for $collectionType")
         }
     }

--- a/src/test/kotlin/com/tyro/oss/arbitrater/InstanceCreatorTest.kt
+++ b/src/test/kotlin/com/tyro/oss/arbitrater/InstanceCreatorTest.kt
@@ -67,9 +67,21 @@ class InstanceCreatorTest {
     }
 
     @Test
+    fun `can generate kotlin nullable enums`() {
+        val kotlinNativeNullableEnums = KotlinNativeNullableEnums::class.arbitraryInstance()
+        println(kotlinNativeNullableEnums)
+    }
+
+    @Test
     fun `can generate Java enums`() {
         val javaEnums =  JavaEnums::class.arbitraryInstance()
         println(javaEnums)
+    }
+
+    @Test
+    fun `can generate Java nullable enums`() {
+        val javaNullableEnums =  JavaNullableEnums::class.arbitraryInstance()
+        println(javaNullableEnums)
     }
 
     @Test
@@ -82,6 +94,12 @@ class InstanceCreatorTest {
     fun `can generate lists of values`() {
         val listOfValues = ListOfValues::class.arbitraryInstance()
         println("listOfValues = $listOfValues")
+    }
+
+    @Test
+    fun `can generate nullable lists of values`() {
+        val nullableListOfValues = NullableListOfValues::class.arbitraryInstance()
+        println("nullableListOfValues = $nullableListOfValues")
     }
 
     @Test
@@ -103,8 +121,20 @@ class InstanceCreatorTest {
     }
 
     @Test
+    fun `can generate nullable sets`() {
+        val instance = NullableSetOfValues::class.arbitraryInstance()
+        println(instance)
+    }
+
+    @Test
     fun `will supply lists if asked to generate a 'collection'`() {
         val instance = CollectionOfValues::class.arbitraryInstance()
+        println(instance)
+    }
+
+    @Test
+    fun `will supply lists if asked to generate a 'nullable collection'`() {
+        val instance = NullableCollectionOfValues::class.arbitraryInstance()
         println(instance)
     }
 
@@ -112,6 +142,12 @@ class InstanceCreatorTest {
     fun `can generate maps`() {
         val instance = MapsOfDtos::class.arbitraryInstance()
         println(instance)
+    }
+
+    @Test
+    fun `can generate nullable map of values`() {
+        val nullableMapOfValues = NullableMapOfDtos::class.arbitraryInstance()
+        println("nullableMapOfValues = $nullableMapOfValues")
     }
 
     @Test

--- a/src/test/kotlin/com/tyro/oss/arbitrater/TestDataClasses.kt
+++ b/src/test/kotlin/com/tyro/oss/arbitrater/TestDataClasses.kt
@@ -26,15 +26,23 @@ import java.util.concurrent.TimeUnit
 
 data class MapsOfDtos(val map: Map<String, NestedClasses>)
 
+data class NullableMapOfDtos(val intList: Map<String, NestedClasses>?)
+
 data class ListOfNonNestedDataClasses(val dtoList: List<Numbers>)
 
 data class ListOfNestedDataClasses(val dtoList: List<NestedClasses>)
 
 data class ListOfValues(val intList: List<Int>)
 
+data class NullableListOfValues(val intList: List<Int>?)
+
 data class SetOfValues(val intList: Set<Int>)
 
+data class NullableSetOfValues(val intList: Set<Int>?)
+
 data class CollectionOfValues(val intCollection: Collection<Int>)
+
+data class NullableCollectionOfValues(val intCollection: Collection<Int>?)
 
 data class DefaultValue(val int: Int = 10)
 
@@ -74,7 +82,11 @@ data class UUIDs(val uuid: UUID)
 
 data class KotlinNativeEnums(val someEnum: SomeEnum)
 
+data class KotlinNativeNullableEnums(val someEnum: SomeEnum?)
+
 data class JavaEnums(val someJavaEnum: TimeUnit)
+
+data class JavaNullableEnums(val someJavaEnum: TimeUnit?)
 
 enum class SomeEnum {
     VALUE_1,


### PR DESCRIPTION
Add support for nullable maps, collections and enums. Attempt 2, at merging this in. Release version 0.0.6