### PR TITLE
Fix registerGenerator not working with kotlin 1.4 and above

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
         <junit.version>5.6.2</junit.version>
     </properties>
 
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>io.kotest</groupId>
             <artifactId>kotest-assertions-core-jvm</artifactId>
-            <version>4.2.3</version>
+            <version>5.1.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Should fix https://github.com/tyro/arbitrater/issues/9

Seems `reflect()` changed in Kotlin 1.4 and above such that it picked up the `Any` from `fun registerGenerator(generator: () -> Any)`. Making this a generic function appears to have worked! Even without marking it as reified, the type came through.

Also noticed while I was in there that `reflect()` started returning null when Java methods were passed in, like `randomBoolean`. Fixed that too by discovering it was being transformed into a `CallableReference`, and we could get the return type off it through reflection. 

Phew!

