### PR TITLE
Two bugs related to Issue 8

### DIFF
--- a/src/test/kotlin/com/tyro/oss/arbitrater/InstanceCreatorTest.kt
+++ b/src/test/kotlin/com/tyro/oss/arbitrater/InstanceCreatorTest.kt
@@ -198,6 +198,40 @@ class InstanceCreatorTest {
         val instance = ClassWithoutConstructorProperty::class.arbitrater().withValue("name", "Boy").createInstance()
         instance.bigName shouldBe "Big Boy"
     }
+
+    @Test
+    fun `withValue should override default value when useDefaults is true`() {
+        // https://github.com/tyro/arbitrater/issues/8
+        val instance = DefaultValue::class.arbitrater()
+            .useDefaultValues(true)
+            .withValue("int", 11)
+            .createInstance()
+
+        instance.int shouldBe 11
+    }
+
+    @Test
+    fun `withValue should override default value when useDefaults is false and called BEFORE withValue`() {
+        // https://github.com/tyro/arbitrater/issues/8
+        val instance = DefaultValue::class.arbitrater()
+            .useDefaultValues(false)
+            .withValue("int", 11)
+            .createInstance()
+
+        instance.int shouldBe 11
+    }
+
+    @Test
+    fun `withValue should override default value when useDefaults is false and called AFTER withValue`() {
+        // https://github.com/tyro/arbitrater/issues/8
+        val instance = DefaultValue::class.arbitrater()
+            .withValue("int", 11)
+            .useDefaultValues(false)
+            .createInstance()
+
+        instance.int shouldBe 11
+    }
+
 }
 
 class TestClass(val property1: String?, val property2: String)


### PR DESCRIPTION
Fixes https://github.com/tyro/arbitrater/issues/8

First issue from @nikimicallef was because of `return this` inside `withValue()`. It mutated the class in place, and `specificValues` map was lost if further config calls were made. I guess either approach would work but can't mix and match, so fixed by making `withValue()` also return a copy.

Second issue - specific values are lost of they are defaulted and `useDefaultsValues` is true was a logic bug, resolved by checking to see if the constructor param is defined and not throwing it away if so.

I guess it should be noted these fixes between them change behaviour that some unfortunate tests may have been accidentally relying on? When released probably worth noting...